### PR TITLE
Make Cloudinary service asynchronous, supporting async / await

### DIFF
--- a/client/src/components/forms/multiple.js
+++ b/client/src/components/forms/multiple.js
@@ -27,7 +27,7 @@ export class MultipleFileForm extends Component {
 
           const response = await axios({
             method: 'post',
-            url: 'http://localhost:5002/api/upload/multiple',
+            url: 'http://localhost:5003/api/upload/multiple',
             data: payload,
             config: { headers: { 'Content-Type': 'multipart/form-data' } }
           });

--- a/client/src/components/forms/single.js
+++ b/client/src/components/forms/single.js
@@ -24,7 +24,7 @@ export class SingleFileForm extends Component {
 
           const response = await axios({
             method: 'post',
-            url: 'http://localhost:5002/api/upload/single',
+            url: 'http://localhost:5003/api/upload/single',
             data: payload,
             config: { headers: { 'Content-Type': 'multipart/form-data' } }
           });

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,25 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+yarn.*

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node -r dotenv/config -r esm server/index.js",
     "start:dev": "concurrently \"yarn run watch:server\" \"yarn run watch:client\"",
-    "watch:server": "nodemon -r dotenv/config -r esm server/index.js",
+    "watch:server": "nodemon -r dotenv/config -r esm .",
     "watch:client": "cd ../client && yarn start"
   },
   "dependencies": {
@@ -14,6 +14,7 @@
     "cors": "^2.8.5",
     "esm": "^3.2.20",
     "express": "^4.16.4",
+    "joi": "^14.3.1",
     "mongoose": "^5.4.19",
     "multer": "^1.4.1"
   },

--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -2,14 +2,17 @@ import { Router } from 'express';
 import multer from 'multer';
 import cloudinary from 'cloudinary';
 
+import CloudinaryService from '../services/cloudinary';
 import { UserModel } from '../models/user';
+import joiValidator from '../utils/joi-validator';
 
-import { CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET } from '../config';
+const { validatePayload, Schemas } = joiValidator;
 
 // Creating an instance of the Express Router that we will export and use in our app.
 const router = Router();
 
-// Creating a multer storage, by not specifying a 'destination' property, we are telling multer to store files in the OS's '/tmp' temporary directory.
+// Creating a multer storage, by not specifying a 'destination' property, we are telling multer to store files in the OS
+//specific '/tmp' temporary directory.
 const storage = multer.diskStorage({
   filename: function(req, file, callback) {
     callback(null, Date.now() + file.originalname);
@@ -32,18 +35,14 @@ const upload = multer({
   limits: { fileSize: 5000000 }
 });
 
-// Configuring the Cloudinary lib to our settings & env variables.
-cloudinary.config({
-  cloud_name: 'moontory',
-  api_key: CLOUDINARY_API_KEY,
-  api_secret: CLOUDINARY_API_SECRET
-});
-
 // API endpoint to upload a single file.
 router.post('/upload/single', upload.single('file'), async (req, res, next) => {
   try {
     // req.file holds multer uploaded file.
     // req.body holds any other form fields, if there are any.
+
+    const tmp = await validatePayload(Schemas.modelSchema, req.body);
+    console.log('tmp', tmp.name);
 
     await cloudinary.v2.uploader.upload(req.file.path, async (err, result) => {
       if (err) {
@@ -54,7 +53,7 @@ router.post('/upload/single', upload.single('file'), async (req, res, next) => {
         });
       }
       // Otherwise, the upload was succesful & push the resulting Cloudinary url to our payload.
-      payload.photo = { url: result.secure_url };
+      // payload.photo = { url: result.secure_url };
 
       // Creating a new User to be saved into the DB.
       const user = new UserModel({
@@ -65,10 +64,12 @@ router.post('/upload/single', upload.single('file'), async (req, res, next) => {
       // Saving the model to the DB and awaiting the results, that we will then send back to the client.
       const payload = await user.save();
 
-      // Send response back to the client.
-      res.status(200).json({
-        payload
-      });
+      if (payload) {
+        // Send response back to the client.
+        res.status(200).json({
+          payload
+        });
+      }
     });
   } catch (error) {
     next(error);
@@ -82,39 +83,20 @@ router.post('/upload/multiple', upload.array('file', 5), async (req, res, next) 
     // req.files holds an array of the multer uploaded files, up to the max of '5'.
     // req.body holds any other form fields, if there are any.
 
-    let photos = []; // Temporary array that will store the uploaded photos url, to then finally be saved into Mongo.
+    const photos = await CloudinaryService.uploadFiles(req.files);
 
-    // Loop through the array of files and upload each one of them to Cloudinary.
-    req.files.forEach(async (values, index, array) => {
-      await cloudinary.v2.uploader.upload(values.path, (err, result) => {
-        if (err) {
-          // In case of an error we log it out and send it back to the client.
-          console.log('err', err);
-          res.status(400).json({
-            err: err
-          });
-        }
+    // Creating a new User to be saved into the DB.
+    const user = new UserModel({
+      name: req.body.name,
+      photos: photos
+    });
 
-        // Otherwise, the upload was succesful & push the resulting Cloudinary url to our array of photos of the payload.
-        photos.push({ url: result.secure_url });
-      });
+    // Saving the model to the DB and awaiting the results, that we will then send back to the client.
+    const payload = await user.save();
 
-      // Only send a response back to the client after all of the files have been properly uploaded.
-      if (photos.length === array.length) {
-        // Creating a new User to be saved into the DB.
-        const user = new UserModel({
-          name: req.body.name,
-          photos: photos
-        });
-
-        // Saving the model to the DB and awaiting the results, that we will then send back to the client.
-        const payload = await user.save();
-
-        // Send response back to the client.
-        res.status(200).json({
-          payload
-        });
-      }
+    // Send response back to the client.
+    res.status(200).json({
+      payload
     });
   } catch (error) {
     next(error);

--- a/server/services/cloudinary/index.js
+++ b/server/services/cloudinary/index.js
@@ -1,0 +1,40 @@
+import cloudinary from 'cloudinary';
+
+import { CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET } from '../../config';
+
+// Configuring the Cloudinary lib to our settings & env variables.
+cloudinary.config({
+  cloud_name: CLOUDINARY_CLOUD_NAME,
+  api_key: CLOUDINARY_API_KEY,
+  api_secret: CLOUDINARY_API_SECRET
+});
+
+export default {
+  /**
+   * Uploads an array of files parsed by multer to cloudinary, and returns an array of strings with the url of the
+   * uploaded files respectivley
+   * @params files An Array of files that have been parsed by the multer middleware normally found in 'req.files''
+   * @returns [String] { url: String } An array of strings containing the uploaded files url.
+   */
+  uploadFiles: function(files) {
+    // The 'Cloudinary' API doesn't return a Promise by default, so we have to excplicitly return one ouselves so that
+    // we can use the new await/async syntax.
+    return new Promise((resolve, reject) => {
+      let payload = []; // Temporary array that will store the uploaded photos url, to then finally be saved into Mong
+
+      // Loop through the array of files and upload each one of them to Cloudinary.
+      files.forEach(async (values, index, array) => {
+        cloudinary.v2.uploader.upload(values.path, (err, result) => {
+          if (err) return reject(err); // In case of an error we reject the promise and pass the error.
+
+          // Otherwise, the upload was succesful & push the resulting Cloudinary url to our array of photos of the payload.
+          payload.push({ url: result.secure_url });
+          // Only send a response back to the client after all of the files have been properly uploaded.
+          if (payload.length === array.length) {
+            resolve(payload);
+          }
+        });
+      });
+    });
+  }
+};

--- a/server/utils/joi-validator/index.js
+++ b/server/utils/joi-validator/index.js
@@ -1,0 +1,37 @@
+import joi from 'joi';
+import Schemas from './joi-schemas';
+
+export default {
+  validateBody: schema => {
+    return (req, res, next) => {
+      const result = joi.validate(req.body, schema);
+      // console.log('joi validate result', result.value);
+
+      if (result.error) {
+        next(result.error);
+      }
+
+      if (!req.value) {
+        req.value = {};
+      }
+
+      req.value['body'] = result.value;
+      next();
+    };
+  },
+
+  validatePayload: (schema, payload) => {
+    // console.log('payload', payload);
+
+    const result = joi.validate(payload, schema);
+    // console.log('joi validate result', result.value);
+
+    if (result.error) {
+      return false;
+    }
+
+    return result.value;
+  },
+
+  Schemas
+};

--- a/server/utils/joi-validator/joi-schemas/index.js
+++ b/server/utils/joi-validator/joi-schemas/index.js
@@ -1,0 +1,7 @@
+import joi from 'joi';
+
+export default {
+  modelSchema: joi.object().keys({
+    name: joi.string()
+  })
+};


### PR DESCRIPTION
Wrapped the image uploading into a seperate function to clean up the API, and also so that we can return a Promise, thus allowing to us to use the async / await syntax inside of our route controller, making for much cleaner code. the official 'cloudinary' npm module doesn't return a promise by default.